### PR TITLE
Add proto media query to navigation buttons

### DIFF
--- a/client/src/components/DivRow.jsx
+++ b/client/src/components/DivRow.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 const DivRow = styled.div`
   display: flex;
   flex-direction: row;
-  justify-content: center;
+  justify-content: center;  
 `;
 
 export default DivRow;

--- a/client/src/components/DropMenu.jsx
+++ b/client/src/components/DropMenu.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const DropMenu = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 42px;
+  left: 200px;
+  z-index: 4;
+  background-color: #ededed;
+  width: 120px;  
+  border-radius: 8px;
+  div {
+    display: flex;
+    border-radius: 6px;
+    justify-content: flex-start;
+    align-items: center;
+    width: 90px;
+    h5 {
+      border: none;
+      padding: 6px;
+      font-size: 13px;
+      margin: 0px;
+      &:hover {}
+    }  
+    &:hover {
+      background-color: #772ce8;
+      h5 {
+        color: white;
+      }
+    }
+  }
+`;
+
+export default DropMenu;

--- a/client/src/components/Follow.jsx
+++ b/client/src/components/Follow.jsx
@@ -147,8 +147,8 @@ class Follow extends React.Component {
               onMouseLeave={this.mouseLeave}
               onClick={this.handleClick}
             >
-              {breakHeart ? <BlackHeart data-box="black" style={{ transition: '400ms', transform: 'scale(1.1)', content: brokenHeart }} />
-                : <BlackHeart data-box="black" style={{ transition: '400ms', transform: 'scale(1)', content: blackHeart }} />}
+              {breakHeart ? <BlackHeart data-box="black" style={{ transition: '440ms', transform: 'scale(1.12)', content: brokenHeart }} />
+                : <BlackHeart data-box="black" style={{ transition: '500ms', transform: 'scale(0.95)', content: blackHeart }} />}
             </Container>
           )}
 

--- a/client/src/components/MainBar.jsx
+++ b/client/src/components/MainBar.jsx
@@ -11,8 +11,11 @@ import Subscribe from './Subscribe';
 import BackgroundPic from './BackgroundPic';
 import Bubble from './Bubble';
 import Live from './Live';
+import Menu from './Menu';
+import DropMenu from './DropMenu';
+import NavButton from './NavButton';
 
-const NavDiv = styled.div`
+const BarDiv = styled.div`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -26,21 +29,8 @@ const Div = styled.div`
   flex-direction: row;
   align-items: center;
   justify-content: ${(props) => (props.nav ? 'space-evenly' : 'center')};
-  padding-left: ${(props) => (props.nav ? '40px' : '10px')};
+  padding-left: 10px;
   padding-right: ${(props) => (props.last ? '10px' : '0px')};
-`;
-
-const NavButton = styled.h5`
-  font-family: 'Roboto', sans-serif;
-  padding-bottom: 8px;
-  font-size: 14px;
-  margin: 0 10px;
-  border-bottom: ${(props) => (props.selected ? 'solid 2px #8643eb' : 'solid 2px white')};
-  color: ${(props) => (props.selected ? '#8643eb' : 'black')};
-  transition: border-bottom 500ms;
-  &:hover {
-    color: #8643eb;
-  }
 `;
 
 const dataSample = data;
@@ -53,6 +43,8 @@ class MainBar extends React.Component {
     this.handleNavClick = this.handleNavClick.bind(this);
     this.handleBubbleIn = this.handleBubbleIn.bind(this);
     this.handleBubbleOut = this.handleBubbleOut.bind(this);
+    this.handleMenuClick = this.handleMenuClick.bind(this);
+    this.handleResizeMain = this.handleResizeMain.bind(this);
     this.state = {
       isLive: true,
       streamerIsClicked: false,
@@ -64,14 +56,19 @@ class MainBar extends React.Component {
       avatarPicUrl: '',
       backgroundPicUrl: '',
       // customEmotesCount: 0,
-      page: 'home',
+      // page: 'home',
       bubbleLive: 0,
       bubbleVerified: 0,
+      page: 'home',
+      windowWidth: window.innerWidth,
+      menuClicked: false,
+      menuPosition: 0,
     };
   }
 
   componentDidMount() {
     this.setState(dataSample);
+    window.addEventListener('resize', this.handleResizeMain);
   }
 
   handleStreamerClick() {
@@ -110,57 +107,95 @@ class MainBar extends React.Component {
     // this.setState({ isSubscribed: true });
   }
 
+  handleResizeMain() {
+    const newWidth = window.innerWidth;
+    this.setState({ windowWidth: newWidth });
+  }
+
+  handleMenuClick(e) {
+    const { menuClicked } = this.state;
+    const rect = e.target.getBoundingClientRect();
+    this.setState({ menuClicked: !menuClicked, menuPosition: rect.x });
+  }
+
   render() {
     const {
       name, backgroundPicUrl, avatarPicUrl, isVerified, isLive, streamerIsClicked, isSubscribed,
-      page, bubbleVerified, bubbleLive,
+      page, bubbleVerified, bubbleLive, menuClicked, menuPosition, windowWidth,
     } = this.state;
     const realUrl = `url(${backgroundPicUrl})`;
 
     return (
-      <DivCol style={{ backgroundColor: 'black' }}>
-        {!streamerIsClicked
+      <DivCol>
+        <DivCol style={{ backgroundColor: 'black' }}>
+          {!streamerIsClicked
+            ? (
+              <BackgroundPic imgUrl={realUrl} style={{ height: '0px', width: '50%', transition: 'height 600ms, width 700ms' }} />
+            )
+            : (
+              <BackgroundPic imgUrl={realUrl} style={{ height: '400px', width: '100%', transition: 'height 600ms, width 600ms' }} />
+            )}
+          <BarDiv>
+
+            <DivRow onClick={this.handleStreamerClick}>
+              <StreamerInfo name={name} avatar={avatarPicUrl} />
+
+              <Div>
+                {isVerified ? <Verified enter={this.handleBubbleIn} leave={this.handleBubbleOut} /> : false}
+                {bubbleVerified ? <Bubble style={{ left: (bubbleVerified + 30) }}>Verified User</Bubble> : false}
+              </Div>
+
+              <Div>
+                {isLive ? <Live data-status="live" onMouseEnter={this.handleBubbleIn} onMouseLeave={this.handleBubbleOut}>LIVE</Live> : false}
+                {bubbleLive ? <Bubble style={{ left: (bubbleLive + 38) }} live>Live Now</Bubble> : false}
+              </Div>
+
+            </DivRow>
+
+            <Menu page={page} buttonClick={this.handleNavClick} dotsClick={this.handleMenuClick} />
+
+            <Div nav last>
+              <Div>
+                <Follow click={this.subscribeClick} />
+              </Div>
+
+              <Div>
+                {isSubscribed ? <Subscribe is /> : <Subscribe />}
+              </Div>
+
+            </Div>
+
+          </BarDiv>
+        </DivCol>
+        {menuClicked
           ? (
-            <BackgroundPic imgUrl={realUrl} style={{ height: '0px', width: '50%', transition: 'height 600ms, width 700ms' }} />
-          )
-          : (
-            <BackgroundPic imgUrl={realUrl} style={{ height: '400px', width: '100%', transition: 'height 600ms, width 600ms' }} />
-          )}
-        <NavDiv>
-
-          <DivRow onClick={this.handleStreamerClick}>
-            <StreamerInfo name={name} avatar={avatarPicUrl} />
-
-            <Div>
-              {isVerified ? <Verified enter={this.handleBubbleIn} leave={this.handleBubbleOut} /> : false}
-              {bubbleVerified ? <Bubble style={{ left: (bubbleVerified + 30) }}>Verified User</Bubble> : false}
-            </Div>
-
-            <Div>
-              {isLive ? <Live data-status="live" onMouseEnter={this.handleBubbleIn} onMouseLeave={this.handleBubbleOut}>LIVE</Live> : false}
-              {bubbleLive ? <Bubble style={{ left: (bubbleLive + 38) }} live>Live Now</Bubble> : false}
-            </Div>
-
-          </DivRow>
-
-          <Div nav>
-            <NavButton data-btnname="home" selected={page === 'home'} onClick={this.handleNavClick}>Home</NavButton>
-            <NavButton data-btnname="videos" selected={page === 'videos'} onClick={this.handleNavClick}>Videos</NavButton>
-            <NavButton data-btnname="clips" selected={page === 'clips'} onClick={this.handleNavClick}>Clips</NavButton>
-            <NavButton data-btnname="followers" selected={page === 'followers'} onClick={this.handleNavClick}>Followers</NavButton>
-          </Div>
-
-          <Div nav last>
-            <Div>
-              <Follow click={this.subscribeClick} />
-            </Div>
-
-            <Div>
-              {isSubscribed ? <Subscribe is /> : <Subscribe />}
-            </Div>
-
-          </Div>
-        </NavDiv>
+            <DropMenu style={{ left: (menuPosition - 65), top: (streamerIsClicked ? '450px' : '50px') }}>
+              {(windowWidth < 676)
+                ? (
+                  <div>
+                    <NavButton data-btnname="videos" selected={page === 'videos'} onClick={this.handleNavClick}>
+                      Videos
+                    </NavButton>
+                  </div>
+                ) : false}
+              {(windowWidth < 746)
+                ? (
+                  <div>
+                    <NavButton data-btnname="clips" selected={page === 'clips'} onClick={this.handleNavClick}>
+                      Clips
+                    </NavButton>
+                  </div>
+                ) : false}
+              {(windowWidth < 801)
+                ? (
+                  <div>
+                    <NavButton data-btnname="followers" selected={page === 'followers'} onClick={this.handleNavClick}>
+                      Followers
+                    </NavButton>
+                  </div>
+                ) : false}
+            </DropMenu>
+          ) : false}
       </DivCol>
     );
   }

--- a/client/src/components/MainBar.jsx
+++ b/client/src/components/MainBar.jsx
@@ -135,6 +135,9 @@ class MainBar extends React.Component {
   }
 
   handleDropdownClick(e) {
+
+    // Incomplete !!!!!
+    
     const { pages, visiblePages } = this.state;
     const { btnname } = e.target.dataset;
     const maxVisibleIndex = visiblePages - 1;

--- a/client/src/components/MainBar.jsx
+++ b/client/src/components/MainBar.jsx
@@ -72,6 +72,7 @@ class MainBar extends React.Component {
 
   componentDidMount() {
     this.setState(dataSample);
+    this.handleResizeMain();
     window.addEventListener('resize', this.handleResizeMain);
   }
 
@@ -113,18 +114,17 @@ class MainBar extends React.Component {
 
   handleResizeMain() {
     const newWidth = window.innerWidth;
-    if (newWidth >= 800) {
-      console.log('back to normal arrangement');
-      this.setState({ windowWidth: newWidth, pages: this.basePages });
-    }
-    if (newWidth < 800) {
-      this.setState({ windowWidth: newWidth, visiblePages: 3 });
-    }
-    if (newWidth < 745) {
-      this.setState({ windowWidth: newWidth, visiblePages: 2 });
-    }
     if (newWidth < 675) {
       this.setState({ windowWidth: newWidth, visiblePages: 1 });
+    }
+    if (newWidth < 745 && newWidth >= 675) {
+      this.setState({ windowWidth: newWidth, visiblePages: 2 });
+    }
+    if (newWidth < 800 && newWidth >= 745) {
+      this.setState({ windowWidth: newWidth, visiblePages: 3 });
+    }
+    if (newWidth >= 800) {
+      this.setState({ windowWidth: newWidth, visiblePages: 4, pages: this.basePages });
     }
   }
 
@@ -135,17 +135,15 @@ class MainBar extends React.Component {
   }
 
   handleDropdownClick(e) {
-
-    // Incomplete !!!!!
-    
-    const { pages, visiblePages } = this.state;
+    const { visiblePages, pages } = this.state;
     const { btnname } = e.target.dataset;
     const maxVisibleIndex = visiblePages - 1;
     const pageToReplace = pages[maxVisibleIndex];
-    console.log('replacing: ', pageToReplace);
-    const newArrangement = pages.splice(maxVisibleIndex, 1, btnname);
-    newArrangement.push(pageToReplace);
-    this.setState({ page: btnname, pages: newArrangement });
+    const indexOfToReplace = pages.indexOf(btnname);
+    const newArrangement = pages.slice();
+    newArrangement.splice(maxVisibleIndex, 1, btnname);
+    newArrangement.splice(indexOfToReplace, 1, pageToReplace);
+    this.setState({ page: btnname, pages: newArrangement, menuClicked: false });
   }
 
   render() {
@@ -172,7 +170,7 @@ class MainBar extends React.Component {
 
               <Div>
                 {isVerified ? <Verified enter={this.handleBubbleIn} leave={this.handleBubbleOut} /> : false}
-                {bubbleVerified ? <Bubble style={{ left: (bubbleVerified + 30) }}>Verified User</Bubble> : false}
+                {bubbleVerified ? <Bubble style={{ left: (bubbleVerified + 22) }}>Verified User</Bubble> : false}
               </Div>
 
               <Div>
@@ -202,25 +200,25 @@ class MainBar extends React.Component {
             <DropMenu style={{ left: (menuPosition - 65), top: (streamerIsClicked ? '450px' : '50px') }}>
               {(windowWidth < 676)
                 ? (
-                  <div>
-                    <NavButton data-btnname="Videos" selected={page === 'Videos'} onClick={this.handleDropdownClick}>
-                      Videos
+                  <div data-btnname={pages[1]} onClick={this.handleDropdownClick}>
+                    <NavButton data-btnname={pages[1]} selected={page === pages[1]} onClick={this.handleDropdownClick}>
+                      {pages[1]}
                     </NavButton>
                   </div>
                 ) : false}
               {(windowWidth < 746)
                 ? (
-                  <div>
-                    <NavButton data-btnname="Clips" selected={page === 'Clips'} onClick={this.handleDropdownClick}>
-                      Clips
+                  <div data-btnname={pages[2]} onClick={this.handleDropdownClick}>
+                    <NavButton data-btnname={pages[2]} selected={page === pages[2]} onClick={this.handleDropdownClick}>
+                      {pages[2]}
                     </NavButton>
                   </div>
                 ) : false}
               {(windowWidth < 801)
                 ? (
-                  <div>
-                    <NavButton data-btnname="Followers" selected={page === 'Followers'} onClick={this.handleDropdownClick}>
-                      Followers
+                  <div data-btnname={pages[3]} onClick={this.handleDropdownClick}>
+                    <NavButton data-btnname={pages[3]} selected={page === pages[3]} onClick={this.handleDropdownClick}>
+                      {pages[3]}
                     </NavButton>
                   </div>
                 ) : false}

--- a/client/src/components/MainBar.jsx
+++ b/client/src/components/MainBar.jsx
@@ -58,7 +58,6 @@ class MainBar extends React.Component {
       avatarPicUrl: '',
       backgroundPicUrl: '',
       // customEmotesCount: 0,
-      // page: 'home',
       bubbleLive: 0,
       bubbleVerified: 0,
       page: 'Home',

--- a/client/src/components/MainBar.jsx
+++ b/client/src/components/MainBar.jsx
@@ -45,6 +45,8 @@ class MainBar extends React.Component {
     this.handleBubbleOut = this.handleBubbleOut.bind(this);
     this.handleMenuClick = this.handleMenuClick.bind(this);
     this.handleResizeMain = this.handleResizeMain.bind(this);
+    this.handleDropdownClick = this.handleDropdownClick.bind(this);
+    this.basePages = ['Home', 'Videos', 'Clips', 'Followers'];
     this.state = {
       isLive: true,
       streamerIsClicked: false,
@@ -59,7 +61,9 @@ class MainBar extends React.Component {
       // page: 'home',
       bubbleLive: 0,
       bubbleVerified: 0,
-      page: 'home',
+      page: 'Home',
+      pages: ['Home', 'Videos', 'Clips', 'Followers'],
+      visiblePages: 4,
       windowWidth: window.innerWidth,
       menuClicked: false,
       menuPosition: 0,
@@ -109,7 +113,19 @@ class MainBar extends React.Component {
 
   handleResizeMain() {
     const newWidth = window.innerWidth;
-    this.setState({ windowWidth: newWidth });
+    if (newWidth >= 800) {
+      console.log('back to normal arrangement');
+      this.setState({ windowWidth: newWidth, pages: this.basePages });
+    }
+    if (newWidth < 800) {
+      this.setState({ windowWidth: newWidth, visiblePages: 3 });
+    }
+    if (newWidth < 745) {
+      this.setState({ windowWidth: newWidth, visiblePages: 2 });
+    }
+    if (newWidth < 675) {
+      this.setState({ windowWidth: newWidth, visiblePages: 1 });
+    }
   }
 
   handleMenuClick(e) {
@@ -118,10 +134,21 @@ class MainBar extends React.Component {
     this.setState({ menuClicked: !menuClicked, menuPosition: rect.x });
   }
 
+  handleDropdownClick(e) {
+    const { pages, visiblePages } = this.state;
+    const { btnname } = e.target.dataset;
+    const maxVisibleIndex = visiblePages - 1;
+    const pageToReplace = pages[maxVisibleIndex];
+    console.log('replacing: ', pageToReplace);
+    const newArrangement = pages.splice(maxVisibleIndex, 1, btnname);
+    newArrangement.push(pageToReplace);
+    this.setState({ page: btnname, pages: newArrangement });
+  }
+
   render() {
     const {
       name, backgroundPicUrl, avatarPicUrl, isVerified, isLive, streamerIsClicked, isSubscribed,
-      page, bubbleVerified, bubbleLive, menuClicked, menuPosition, windowWidth,
+      page, pages, bubbleVerified, bubbleLive, menuClicked, menuPosition, windowWidth,
     } = this.state;
     const realUrl = `url(${backgroundPicUrl})`;
 
@@ -152,7 +179,7 @@ class MainBar extends React.Component {
 
             </DivRow>
 
-            <Menu page={page} buttonClick={this.handleNavClick} dotsClick={this.handleMenuClick} />
+            <Menu pages={pages} page={page} buttonClick={this.handleNavClick} dotsClick={this.handleMenuClick} />
 
             <Div nav last>
               <Div>
@@ -173,7 +200,7 @@ class MainBar extends React.Component {
               {(windowWidth < 676)
                 ? (
                   <div>
-                    <NavButton data-btnname="videos" selected={page === 'videos'} onClick={this.handleNavClick}>
+                    <NavButton data-btnname="Videos" selected={page === 'Videos'} onClick={this.handleDropdownClick}>
                       Videos
                     </NavButton>
                   </div>
@@ -181,7 +208,7 @@ class MainBar extends React.Component {
               {(windowWidth < 746)
                 ? (
                   <div>
-                    <NavButton data-btnname="clips" selected={page === 'clips'} onClick={this.handleNavClick}>
+                    <NavButton data-btnname="Clips" selected={page === 'Clips'} onClick={this.handleDropdownClick}>
                       Clips
                     </NavButton>
                   </div>
@@ -189,7 +216,7 @@ class MainBar extends React.Component {
               {(windowWidth < 801)
                 ? (
                   <div>
-                    <NavButton data-btnname="followers" selected={page === 'followers'} onClick={this.handleNavClick}>
+                    <NavButton data-btnname="Followers" selected={page === 'Followers'} onClick={this.handleDropdownClick}>
                       Followers
                     </NavButton>
                   </div>

--- a/client/src/components/Menu.jsx
+++ b/client/src/components/Menu.jsx
@@ -49,25 +49,32 @@ class Menu extends React.Component {
 
   render() {
     const { windowWidth } = this.state;
-    const { buttonClick, page } = this.props;
+    // eslint-disable-next-line react/prop-types
+    const { buttonClick, page, pages, dotsClick } = this.props;
     return (
       <NavDiv>
-        <NavButton data-btnname="home" selected={page === 'home'} onClick={buttonClick}>Home</NavButton>
-        {(windowWidth > 675)
+        <NavButton data-btnname="Home" selected={page === 'Home'} onClick={buttonClick}>Home</NavButton>
+        {(windowWidth >= 675)
           ? (
-            <NavButton data-btnname="videos" selected={page === 'videos'} onClick={buttonClick}>Videos</NavButton>
+            <NavButton data-btnname={pages[1]} selected={page === pages[1]} onClick={buttonClick}>
+              {pages[1]}
+            </NavButton>
           ) : false}
-        {(windowWidth > 745)
+        {(windowWidth >= 745)
           ? (
-            <NavButton data-btnname="clips" selected={page === 'clips'} onClick={buttonClick}>Clips</NavButton>
+            <NavButton data-btnname={pages[2]} selected={page === pages[2]} onClick={buttonClick}>
+              {pages[2]}
+            </NavButton>
           ) : false}
-        {(windowWidth > 800)
+        {(windowWidth >= 800)
           ? (
-            <NavButton data-btnname="followers" selected={page === 'followers'} onClick={buttonClick}>Followers</NavButton>
+            <NavButton data-btnname={pages[3]} selected={page === pages[3]} onClick={buttonClick}>
+              {pages[3]}
+            </NavButton>
           ) : false}
-        {(windowWidth < 801)
+        {(windowWidth < 800)
           ? (
-            <DivM onClick={this.props.dotsClick}>
+            <DivM onClick={dotsClick}>
               <NavDots />
               <NavDots />
               <NavDots />

--- a/client/src/components/Menu.jsx
+++ b/client/src/components/Menu.jsx
@@ -53,7 +53,9 @@ class Menu extends React.Component {
     const { buttonClick, page, pages, dotsClick } = this.props;
     return (
       <NavDiv>
-        <NavButton data-btnname="Home" selected={page === 'Home'} onClick={buttonClick}>Home</NavButton>
+        <NavButton data-btnname={pages[0]} selected={page === pages[0]} onClick={buttonClick}>
+          {pages[0]}
+        </NavButton>
         {(windowWidth >= 675)
           ? (
             <NavButton data-btnname={pages[1]} selected={page === pages[1]} onClick={buttonClick}>

--- a/client/src/components/Menu.jsx
+++ b/client/src/components/Menu.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import styled from 'styled-components';
+import NavButton from './NavButton';
+
+const NavDiv = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding-left: 40px;
+`;
+
+const DivM = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;  
+  padding-bottom:  8px; 
+  margin: 0 10px;
+  &:hover {
+    div {
+      background-color: #8643eb;
+    }
+  }
+`;
+
+const NavDots = styled.div`
+  background-color: black;
+  border-radius: 50%;
+  width: 5px;
+  height: 5px;
+  margin: 0 1px; 
+`;
+
+class Menu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { windowWidth: window.innerWidth };
+    this.handleResize = this.handleResize.bind(this);
+  }
+
+  componentDidMount() {
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  handleResize() {
+    const newWidth = window.innerWidth;
+    this.setState({ windowWidth: newWidth });
+  }
+
+  render() {
+    const { windowWidth } = this.state;
+    const { buttonClick, page } = this.props;
+    return (
+      <NavDiv>
+        <NavButton data-btnname="home" selected={page === 'home'} onClick={buttonClick}>Home</NavButton>
+        {(windowWidth > 675)
+          ? (
+            <NavButton data-btnname="videos" selected={page === 'videos'} onClick={buttonClick}>Videos</NavButton>
+          ) : false}
+        {(windowWidth > 745)
+          ? (
+            <NavButton data-btnname="clips" selected={page === 'clips'} onClick={buttonClick}>Clips</NavButton>
+          ) : false}
+        {(windowWidth > 800)
+          ? (
+            <NavButton data-btnname="followers" selected={page === 'followers'} onClick={buttonClick}>Followers</NavButton>
+          ) : false}
+        {(windowWidth < 801)
+          ? (
+            <DivM onClick={this.props.dotsClick}>
+              <NavDots />
+              <NavDots />
+              <NavDots />
+            </DivM>
+          ) : false}
+      </NavDiv>
+    );
+  }
+}
+
+export default Menu;

--- a/client/src/components/NavButton.jsx
+++ b/client/src/components/NavButton.jsx
@@ -1,0 +1,16 @@
+import styled from 'styled-components';
+
+const NavButton = styled.h5`
+  font-family: 'Roboto', sans-serif;
+  padding-bottom: 8px;
+  font-size: 14px;
+  margin: 0 10px;
+  border-bottom: ${(props) => (props.selected ? 'solid 2px #8643eb' : 'solid 2px white')};
+  color: ${(props) => (props.selected ? '#8643eb' : 'black')};
+  transition: border-bottom 500ms;
+  &:hover {
+    color: #8643eb;
+  }
+`;
+
+export default NavButton;

--- a/server/seeder.js
+++ b/server/seeder.js
@@ -1,48 +1,48 @@
 const mongo = require('./db.js');
 const emos = require('./emojis');
 
-const word1 = ['Alpha', '', '', '', '', 'Beta', 'Gamma', 'Delta', 'Master', 'Speed', 'Legendary', 'Love', 'White', "Black", 'Blue', 'Magic', 'Tiny', 'Brutal', 'Technical'];
-const word2 = ['Robot', '', '', '', '', "Ninja", "Samurai", "Demon", "John", "Ranger", "", "Elton", "star", "Night", "Bro", "Tony", "Gamer", "Troll", "Wizard", "Soldier"];
-const prefix = ['The', "I'mThe", '', '', '', 'Your', 'My'];
+const word1 = ['Alpha', '', '', '', '', 'Beta', 'Gamma', 'Delta', 'Master', 'Speed', 'Legendary', 'Love', 'White', 'Black', 'Blue', 'Magic', 'Tiny', 'Brutal', 'Technical'];
+const word2 = ['Robot', '', '', '', '', 'Ninja', 'Samurai', 'Demon', 'John', 'Ranger', '', 'Elton', 'star', 'Night', 'Bro', 'Tony', 'Gamer', 'Troll', 'Wizard', 'Soldier'];
+const prefix = ['The', '', '', '', '', 'Your', 'My'];
 const sufix = ['99', 'XX', 'XP', 'GP', 'GT', '2000', '87', '', '', '', '', '', '666', 'Tron', '88', 'GG'];
 
 const emojiList = Object.keys(emos.emos);
 
-const randomStreamerName = function(){
-  return [randomElement(prefix), randomElement(word1), randomElement(word2), randomElement(sufix)].join('');
-};
-
-const randomElement = function(array){
-  let randomIndex = Math.floor(Math.random() * array.length);
+const randomElement = (array) => {
+  const randomIndex = Math.floor(Math.random() * array.length);
   return array[randomIndex];
 };
 
-const getRandomInt = (min, max) => {
-  min = Math.ceil(min);
-  max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min)) + min; //The maximum is exclusive and the minimum is inclusive
-}
+const randomStreamerName = () => [randomElement(prefix), randomElement(word1), randomElement(word2), randomElement(sufix)].join('');
+
+const getRandomInt = (floor, celing) => {
+  const min = Math.ceil(floor);
+  const max = Math.floor(celing);
+  return Math.floor(Math.random() * (max - min)) + min; 
+};
 
 const randomSet = (array) => {
-  let result = [];
-  let setSize = getRandomInt(16, 61);
-  for (let i = 0; i < setSize; i++) {
-    let randomIndex = Math.floor(Math.random() * array.length);
+  const result = [];
+  const setSize = getRandomInt(16, 61);
+  for (let i = 0; i < setSize; i += 1) {
+    const randomIndex = Math.floor(Math.random() * array.length);
     result.push(array[randomIndex]);
   }
   return result;
-}
+};
 
-let mongoObjects = [];
+const mongoObjects = [];
 
-for (let i = 0; i < 100; i++) {
-  let o = {};
+for (let i = 0; i < 100; i += 1) {
+  const o = {};
   o.name = randomStreamerName();
   o.avatarPicUrl = 'https://loremflickr.com/80/80';
   o.backgroundPicUrl = 'https://loremflickr.com/600/400';
   o.subscriptionEmotes = [randomElement(emojiList), randomElement(emojiList), randomElement(emojiList), randomElement(emojiList), randomElement(emojiList)];
   o.customEmotes = randomSet(emojiList);
   o.customEmotesCount = o.customEmotes.length;
+  o.followersCount = getRandomInt(0, 20000);
+  o.subscribers = getRandomInt(0, 1000);
   mongoObjects.push(o);
 }
 


### PR DESCRIPTION
Given the complexity of the navigation bar, I had to keep the state
lifted at the main component so that it could be passed down via props
to both sets of navigation buttons. Upon mounting, both the main comp
and the Menu comp add an event listener to the window object that
updates their state, this allows the nav buttons to change based on
window resize. I still need to polish the onClick listener on the
drop-down menu so the order of the buttons is chamnged.